### PR TITLE
fix: resolve audio engine initialization failure and add recovery

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,9 +450,14 @@
     // FFmpeg.wasm setup - expose modules globally
     window.FFmpegWASM = {};
     window.FFmpegUtil = {};
+    window.FFmpegLoadErrors = [];
   </script>
-  <script src="https://unpkg.com/@ffmpeg/ffmpeg@0.12.7/dist/umd/ffmpeg.js" onload="window.FFmpegWASM.FFmpeg = FFmpegWASM.FFmpeg"></script>
-  <script src="https://unpkg.com/@ffmpeg/util@0.12.1/dist/umd/index.js" onload="window.FFmpegUtil.fetchFile = FFmpegUtil.fetchFile"></script>
+  <script src="https://unpkg.com/@ffmpeg/ffmpeg@0.12.7/dist/umd/ffmpeg.js"
+    onload="window.FFmpegWASM.FFmpeg = FFmpegWASM.FFmpeg"
+    onerror="console.error('[reSOURCERY] Failed to load FFmpeg library from CDN'); window.FFmpegLoadErrors.push('ffmpeg')"></script>
+  <script src="https://unpkg.com/@ffmpeg/util@0.12.1/dist/umd/index.js"
+    onload="window.FFmpegUtil.fetchFile = FFmpegUtil.fetchFile"
+    onerror="console.error('[reSOURCERY] Failed to load FFmpeg utilities from CDN'); window.FFmpegLoadErrors.push('util')"></script>
   <script src="js/version.js"></script>
   <script src="js/fft.js"></script>
   <script src="js/tempo-detector.js"></script>

--- a/js/version.js
+++ b/js/version.js
@@ -10,7 +10,7 @@
 const APP_VERSION = Object.freeze({
   major: 2,
   minor: 1,
-  patch: 1,
+  patch: 2,
 
   /** Full semver string, e.g. "2.1.0" */
   get full() {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'resourcery-v2.1.1';
+const CACHE_NAME = 'resourcery-v2.1.2';
 const STATIC_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
- Reset processor state (ffmpeg, isLoaded) on initialization failure
  so users can retry without refreshing the page
- Add onerror handlers to CDN script tags for early failure detection
  instead of waiting 10s for polling timeout
- Fix object URL memory leak in audio playback (revoke on reset/reload)
- Surface specific error messages to user instead of generic text
- Bump version to 2.1.2

https://claude.ai/code/session_01PiEgvRXhwVDDU58gxP2ZUQ