### PR TITLE
fix: resolve 503 error on iPhone video upload and improve audio extraction

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
               <span class="format-badge">M4A</span>
             </div>
           </div>
-          <input type="file" id="fileInput" accept="audio/*,video/*" hidden>
+          <input type="file" id="fileInput" accept="audio/*,video/*,.mp4,.mov,.m4v,.mkv,.avi,.webm,.mp3,.wav,.m4a,.aac,.flac,.ogg,.wma" hidden>
         </div>
       </section>
 

--- a/js/app.js
+++ b/js/app.js
@@ -327,6 +327,12 @@ class ReSOURCERYApp {
         return;
       }
 
+      // Validate file type — reject files that aren't audio or video
+      if (type === 'file' && source.type && !source.type.startsWith('audio/') && !source.type.startsWith('video/')) {
+        this.showToast('Unsupported file type. Please upload an audio or video file.', 'error');
+        return;
+      }
+
       // Show processing section
       this.showSection('processing');
 


### PR DESCRIPTION
- Service worker now uses cache-first strategy for CDN assets instead of
  returning HTTP 503 when network fails (the root cause of the reported error)
- Add retry with exponential backoff for CDN fetches (1s, 2s, 4s) to handle
  flaky mobile connections
- Add MIME-type-based file extension inference for iPhone videos that lack
  recognized extensions (e.g. MOV, HEVC containers)
- Expand file input accept attribute with explicit extensions for better iOS
  Safari file picker compatibility
- Validate FFmpeg extraction output to catch missing audio tracks early
- Add file type validation before processing to reject non-media uploads
- Improve error messages for common failure modes (no audio track, OOM)

https://claude.ai/code/session_01MWAc5T7DpEFVWK4QuYNVik