### PR TITLE
fix: resolve PWA runtime stall at 23% by adding download timeouts, load retry, and error surfacing

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,9 @@
-const CACHE_NAME = 'resourcery-v2.2.0';
+// Derive cache name from centralized version config (js/version.js)
+// so deploys automatically invalidate stale caches including wasm assets.
+try { importScripts('./js/version.js'); } catch (e) { /* version.js unavailable */ }
+const CACHE_NAME = (typeof APP_VERSION !== 'undefined' && APP_VERSION.cacheKey)
+  ? APP_VERSION.cacheKey
+  : 'resourcery-v2.2.0';
 const STATIC_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
The 23% stall was caused by FFmpeg.wasm asset downloads (core JS, WASM
binary, worker script) having no timeout — a stalled connection would
hang indefinitely. Additionally, ffmpeg.load() had no retry mechanism,
so transient instantiation failures were fatal.

Changes:
- Add withTimeout (30s/60s) around each FFmpeg asset download to prevent
  indefinite hangs on flaky mobile connections
- Add exponential backoff retry (max 3 attempts) on ffmpeg.load() to
  recover from transient WASM instantiation failures
- Add crossOriginIsolated runtime check with console warning when
  SharedArrayBuffer may be unavailable
- Wrap writeFile, exec, readFile, and decodeAudioData in granular
  try/catch blocks with console.error so failures surface visibly
  instead of dying silently
- Improve progress phase labels ("Downloading processing core (~25 MB)",
  "Writing file to audio engine...", "Starting audio engine...")
- Version the service worker cache key dynamically via importScripts
  from js/version.js so deploys automatically invalidate stale caches
  (including cached WASM binaries)

https://claude.ai/code/session_018ezfYCT8cjsM6dYBYST6EP