### PR TITLE
feat: add safe area insets for curved screens, GitHub Pages deployment, CI enhancements (v2.3.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,23 @@ jobs:
           test -f .editorconfig
           test -f index.html
           test -f vercel.json
+          test -f manifest.json
           test -f css/styles.css
           test -f js/app.js
           test -f js/audio-processor.js
+          test -f js/version.js
+          test -f sw.js
           test -f docs/MANIFEST.md
+
+      - name: Version consistency check
+        run: |
+          VERSION=$(node -e "
+            const fs = require('fs');
+            const src = fs.readFileSync('js/version.js', 'utf8');
+            const m = src.match(/major:\s*(\d+)[\s\S]*?minor:\s*(\d+)[\s\S]*?patch:\s*(\d+)/);
+            console.log('resourcery-v' + m[1] + '.' + m[2] + '.' + m[3]);
+          ")
+          FALLBACK=$(grep -oP "resourcery-v[\d.]+" sw.js | head -1)
+          echo "version.js cacheKey: $VERSION"
+          echo "sw.js fallback: $FALLBACK"
+          test "$VERSION" = "$FALLBACK" || { echo "ERROR: sw.js fallback cache name does not match version.js cacheKey"; exit 1; }

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to reSOURCERY will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-02-22
+
+### Safe Area & Deployment
+
+#### Added
+- **Safe area insets for curved/notched screens**: Applied `env(safe-area-inset-left)` and `env(safe-area-inset-right)` padding to `.app-container`, adjusted `.floating-menu-btn` right position and `.toast-container` width to respect side safe areas. Background color extends naturally behind safe areas via existing `viewport-fit=cover`.
+- **GitHub Pages deployment workflow** (`.github/workflows/deploy-pages.yml`): Automatic static deployment to GitHub Pages on pushes to `main` using `actions/deploy-pages@v4`.
+- **CI version consistency check**: New CI step validates that `sw.js` fallback cache name matches `APP_VERSION.cacheKey` from `js/version.js`.
+- **CI baseline additions**: Added `manifest.json`, `js/version.js`, and `sw.js` to repository smoke checks.
+- README: Added CI status badge, GitHub Pages deployment badge, expanded deployment documentation covering Vercel, GitHub Pages, and custom static hosts with header requirements.
+
+#### Changed
+- Service worker cache bumped to `resourcery-v2.3.0`.
+- README version badge updated to 2.3.0.
+
 ## [2.2.0] - 2026-02-21
 
 ### Audio Processing & Deployment

--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-2.2.0-blue.svg" alt="Version"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-2.3.0-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg" alt="License"></a>
+  <a href="https://github.com/SeanVasey/reSOURCERY/actions/workflows/ci.yml"><img src="https://github.com/SeanVasey/reSOURCERY/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/badge/platform-Web%20%7C%20iOS%20%7C%20Android-lightgrey.svg" alt="Platform">
   <img src="https://img.shields.io/badge/PWA-enabled-blueviolet.svg" alt="PWA">
   <img src="https://img.shields.io/badge/iOS-primary-000000.svg?logo=apple&logoColor=white" alt="iOS">
   <a href="SECURITY.md"><img src="https://img.shields.io/badge/security-fixes%20applied-brightgreen.svg" alt="Security"></a>
   <img src="https://img.shields.io/badge/design-mobile%20first-orange.svg" alt="Mobile First">
   <img src="https://img.shields.io/badge/deploy-Vercel%20ready-black.svg?logo=vercel&logoColor=white" alt="Vercel">
+  <img src="https://img.shields.io/badge/deploy-GitHub%20Pages-222.svg?logo=github&logoColor=white" alt="GitHub Pages">
   <img src="https://img.shields.io/badge/status-active-success.svg" alt="Status">
 </p>
 
@@ -86,15 +88,42 @@ curl -I http://127.0.0.1:50910/
 
 > **Note**: Requires HTTPS or localhost for full PWA + Service Worker functionality.
 
-### Vercel Deployment
+### Deployment
+
+reSOURCERY is a static site — no build step is needed. Deploy the repository root directly.
+
+#### Vercel (Recommended)
 
 The project includes `vercel.json` pre-configured with:
 - `Cross-Origin-Embedder-Policy: credentialless` — enables SharedArrayBuffer for FFmpeg.wasm
 - `Cross-Origin-Opener-Policy: same-origin` — required for cross-origin isolation
-- Cache headers for static assets
-- SPA rewrite rules
+- Cache headers for static assets (JS/CSS: 1 day + stale-while-revalidate, icons: 7 days)
+- Service worker files (`sw.js`, `coi-serviceworker.js`) set to `no-cache` for instant updates
+- SPA rewrite rules for client-side routing
 
-Deploy directly from the repository — no build step required.
+To deploy: connect the repository to Vercel and push to `main`. No framework or build command is needed.
+
+#### GitHub Pages
+
+A GitHub Actions workflow (`.github/workflows/deploy-pages.yml`) is included for automatic deployment to GitHub Pages on pushes to `main`.
+
+To enable:
+1. Go to **Settings > Pages** in the repository
+2. Under **Source**, select **GitHub Actions**
+3. Push to `main` — the workflow will deploy automatically
+
+> **Note**: GitHub Pages does not support custom response headers. Cross-origin isolation headers (COOP/COEP) are handled at runtime by `coi-serviceworker.js`, which intercepts fetch requests and injects the required headers. FFmpeg.wasm SharedArrayBuffer support works on GitHub Pages through this service worker approach.
+
+#### Custom Static Host
+
+For any static hosting provider, ensure these response headers are set:
+| Header | Value | Purpose |
+| --- | --- | --- |
+| `Cross-Origin-Embedder-Policy` | `credentialless` | SharedArrayBuffer for FFmpeg.wasm |
+| `Cross-Origin-Opener-Policy` | `same-origin` | Cross-origin isolation |
+| `Service-Worker-Allowed` | `/` | Allow service worker scope |
+
+If custom headers cannot be configured, `coi-serviceworker.js` provides a runtime fallback.
 
 ## Architecture
 
@@ -103,7 +132,7 @@ reSOURCERY/
 ├── index.html              # Main PWA interface
 ├── manifest.json           # PWA manifest (standalone, portrait)
 ├── vercel.json             # Vercel deployment headers & config
-├── sw.js                   # Service worker (v2.2.0)
+├── sw.js                   # Service worker (v2.3.0)
 ├── coi-serviceworker.js    # Cross-Origin Isolation for SharedArrayBuffer
 ├── css/
 │   └── styles.css          # Dark slate + indigo/cyan wizard theme
@@ -143,6 +172,7 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
 | Version | Date       | Summary                                |
 | ------- | ---------- | -------------------------------------- |
+| 2.3.0   | 2026-02-22 | Safe area insets for curved screens, GitHub Pages deployment, CI enhancements |
 | 2.2.0   | 2026-02-21 | Fix audio upload/URL processing, Vercel deployment, security hardening |
 | 2.1.2   | 2026-02-19 | Version config patch alignment         |
 | 2.1.1   | 2026-02-18 | FFmpeg upload/initialization reliability fixes, CI baseline checks |
@@ -173,7 +203,11 @@ test -f SECURITY.md && test -f index.html && test -f css/styles.css && \
 test -f js/app.js && test -f js/audio-processor.js && echo "All checks passed"
 ```
 
-GitHub Actions runs the same checks on pull requests and pushes to `main` (see `.github/workflows/ci.yml`).
+### CI / CD
+
+GitHub Actions runs these checks automatically:
+- **CI** (`.github/workflows/ci.yml`) — syntax checks, baseline smoke checks, and version consistency validation on all PRs and pushes to `main`
+- **Deploy** (`.github/workflows/deploy-pages.yml`) — deploys to GitHub Pages on pushes to `main`
 
 ## Technology Stack
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -156,6 +156,9 @@ body::before {
   min-height: 100dvh;
   background: var(--gradient-dark-vertical);
   position: relative;
+  /* Safe area side padding for curved/notched screens — background extends behind via viewport-fit=cover */
+  padding-left: var(--safe-left);
+  padding-right: var(--safe-right);
 }
 
 /* Ambient Background - Dark indigo-blue glow */
@@ -186,7 +189,7 @@ body::before {
 .floating-menu-btn {
   position: fixed;
   top: calc(var(--safe-top) + 16px);
-  right: 16px;
+  right: calc(var(--safe-right) + 16px);
   z-index: 200;
   width: 44px;
   height: 44px;
@@ -1597,7 +1600,7 @@ body::before {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
-  width: calc(100% - var(--space-lg) * 2);
+  width: calc(100% - var(--space-lg) * 2 - var(--safe-left) - var(--safe-right));
   max-width: 400px;
   pointer-events: none;
 }

--- a/js/version.js
+++ b/js/version.js
@@ -9,7 +9,7 @@
 
 const APP_VERSION = Object.freeze({
   major: 2,
-  minor: 2,
+  minor: 3,
   patch: 0,
 
   /** Full semver string, e.g. "2.1.0" */

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 try { importScripts('./js/version.js'); } catch (e) { /* version.js unavailable */ }
 const CACHE_NAME = (typeof APP_VERSION !== 'undefined' && APP_VERSION.cacheKey)
   ? APP_VERSION.cacheKey
-  : 'resourcery-v2.2.0';
+  : 'resourcery-v2.3.0';
 const STATIC_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
Apply left/right safe area padding to app container, floating menu button,
and toast container so content is not clipped on devices with curved screens
or notches. Background color extends naturally behind safe areas via
viewport-fit=cover.

Add GitHub Pages deployment workflow, CI version consistency check between
version.js and sw.js, and expanded README deployment documentation covering
Vercel, GitHub Pages, and custom static hosts.

https://claude.ai/code/session_018McEvXudzVtKev7aynsCfZ