### PR TITLE
fix: stop fetching missing FFmpeg worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **FFmpeg media initialization**: The app no longer fetches or passes `ffmpeg-core.worker.js` for the default single-threaded `@ffmpeg/core` build, because that package does not ship a worker script. This prevents media handling from failing before processing starts or timing out while preparing the audio engine.
 - **Top safe-area scrim**: Page content no longer scrolls visibly into the iOS status bar / notch / Dynamic Island region. A fixed, pointer-transparent `.top-safe-scrim` layer replicates the page background stack — `--color-bg-primary` (the top stop of `--gradient-dark-vertical`), the animated ambient glow, and the noise texture — opaque through `env(safe-area-inset-top)` with a short (≤16px) masked fade below it, so the inset is indistinguishable from the page background at rest (the fade lets the hero glow bleed through without a clipped edge) and scrolling content blends out before reaching the status icons. The ambient gradient and noise texture were promoted to `:root` custom properties (`--gradient-ambient`, `--noise-texture`) so the scrim and page share one definition.
 
 ## [2.4.0] - 2026-02-27

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,7 @@ When updating the footer, ensure the version in `.footer-app-tag` stays in sync 
 
 ## Common Pitfalls
 
-- **FFmpeg stall at 20-30%**: Ensure `ffmpeg-core.worker.js` is pre-fetched and passed as blob URL to `ffmpeg.load()`; without it the loader tries to resolve relative to a blob: URL and hangs
+- **FFmpeg stall at 20-30%**: The default `@ffmpeg/core` package is single-threaded and does not ship `ffmpeg-core.worker.js`; only fetch/pass `workerURL` when intentionally switching to a multi-threaded core package that provides one.
 - **Sample rate 0**: If FFmpeg probe fails to parse audio metadata, `extractAudio` receives `sampleRate: 0`; the code defaults to 48000 Hz in this case
 - **CORS on URL fetch**: Cross-origin media URLs will fail unless the remote server sends CORS headers; the app falls back to the `/api/fetch` proxy
 - **Vercel COEP**: Use `credentialless` (not `require-corp`) to allow CDN fetches without CORS headers on every resource

--- a/js/audio-processor.js
+++ b/js/audio-processor.js
@@ -17,7 +17,10 @@ class AudioProcessor {
     this.ffmpegCoreConfig = {
       coreURL: 'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd/ffmpeg-core.js',
       wasmURL: 'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd/ffmpeg-core.wasm',
-      workerURL: 'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd/ffmpeg-core.worker.js'
+      // @ffmpeg/core is the single-threaded build; it intentionally has no
+      // ffmpeg-core.worker.js. Fetching a non-existent worker script makes
+      // every processing attempt fail before user media is handled.
+      workerURL: null
     };
 
     this.proxyEndpoint = '/api/fetch';
@@ -423,25 +426,28 @@ class AudioProcessor {
       const wasmBlob = new Blob([wasmData], { type: 'application/wasm' });
       const wasmBlobURL = URL.createObjectURL(wasmBlob);
 
-      // Download worker script so ffmpeg.load can resolve worker from blob URLs.
-      // Without this, the loader can stall around ~20-30% while trying to fetch
-      // ffmpeg-core.worker.js relative to a blob: URL.
-      this.updateStage('Preparing audio worker...');
-      let workerData;
-      try {
-        workerData = await this.withTimeout(
-          this.fetchWithProgress(workerURL, (progress) => {
-            this.updateProgress(23 + Math.round(progress * 2));
-          }),
-          30000,
-          'Audio worker download timed out. Please check your connection and try again.'
-        );
-      } catch (err) {
-        console.error('[AudioProcessor] Worker script download failed:', err);
-        throw err;
+      let workerBlobURL = null;
+      if (workerURL) {
+        // Multi-threaded FFmpeg cores need a worker script. The default
+        // single-threaded @ffmpeg/core build does not ship one, so only fetch
+        // this when a valid worker URL is explicitly configured.
+        this.updateStage('Preparing audio worker...');
+        let workerData;
+        try {
+          workerData = await this.withTimeout(
+            this.fetchWithProgress(workerURL, (progress) => {
+              this.updateProgress(23 + Math.round(progress * 2));
+            }),
+            30000,
+            'Audio worker download timed out. Please check your connection and try again.'
+          );
+        } catch (err) {
+          console.error('[AudioProcessor] Worker script download failed:', err);
+          throw err;
+        }
+        const workerBlob = new Blob([workerData], { type: 'text/javascript' });
+        workerBlobURL = URL.createObjectURL(workerBlob);
       }
-      const workerBlob = new Blob([workerData], { type: 'text/javascript' });
-      const workerBlobURL = URL.createObjectURL(workerBlob);
 
       // Load FFmpeg core with pre-downloaded blob URLs
       // Retry with exponential backoff (max 3 attempts) for transient failures
@@ -459,7 +465,7 @@ class AudioProcessor {
             this.ffmpeg.load({
               coreURL: coreJSBlobURL,
               wasmURL: wasmBlobURL,
-              workerURL: workerBlobURL,
+              ...(workerBlobURL ? { workerURL: workerBlobURL } : {}),
             }),
             45000,
             'Audio engine initialization timed out. Please refresh and retry.'
@@ -496,8 +502,8 @@ class AudioProcessor {
       }
 
       // Revoke core JS and WASM blob URLs — they are no longer needed after
-      // ffmpeg.load() compiles the WASM module.  Keep the worker blob URL alive
-      // because FFmpeg's internal Web Worker may still reference it; it gets
+      // ffmpeg.load() compiles the WASM module. Keep an optional worker blob URL
+      // alive because FFmpeg's internal Web Worker may reference it; it gets
       // revoked in destroy() instead.
       URL.revokeObjectURL(coreJSBlobURL);
       URL.revokeObjectURL(wasmBlobURL);
@@ -505,7 +511,7 @@ class AudioProcessor {
 
       if (lastLoadError) {
         // Worker URL is also useless on failure — clean it up now
-        URL.revokeObjectURL(workerBlobURL);
+        if (workerBlobURL) URL.revokeObjectURL(workerBlobURL);
         this._workerBlobURL = null;
         throw lastLoadError;
       }

--- a/sw.js
+++ b/sw.js
@@ -28,8 +28,7 @@ const CDN_ASSETS = [
   'https://unpkg.com/@ffmpeg/ffmpeg@0.12.7/dist/umd/ffmpeg.js',
   'https://unpkg.com/@ffmpeg/util@0.12.1/dist/umd/index.js',
   'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd/ffmpeg-core.js',
-  'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd/ffmpeg-core.wasm',
-  'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd/ffmpeg-core.worker.js'
+  'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd/ffmpeg-core.wasm'
 ];
 
 // Install event - cache static assets

--- a/tests/audio-processor-config.test.js
+++ b/tests/audio-processor-config.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/audio-processor.js', 'utf8');
+const context = {
+  console,
+  setTimeout,
+  clearTimeout,
+  URL,
+  Blob,
+};
+vm.createContext(context);
+vm.runInContext(`${source}\nglobalThis.AudioProcessor = AudioProcessor;`, context);
+
+const processor = new context.AudioProcessor({ useWebWorker: false });
+assert.strictEqual(processor.ffmpegCoreConfig.workerURL, null, 'single-threaded @ffmpeg/core must not fetch a missing worker script');
+assert.match(processor.ffmpegCoreConfig.coreURL, /@ffmpeg\/core@0\.12\.6/);
+assert.match(processor.ffmpegCoreConfig.wasmURL, /@ffmpeg\/core@0\.12\.6/);
+
+console.log('audio processor FFmpeg core configuration is valid');


### PR DESCRIPTION
### Motivation
- The app used the `ffmpeg-core.worker.js` URL unconditionally while the configured `@ffmpeg/core` package is a single-threaded build that does not ship a worker script, which caused FFmpeg initialization to fail or hang before any user media was processed.

### Description
- Set `ffmpegCoreConfig.workerURL` to `null` by default and only fetch/create a worker blob when a valid `workerURL` is explicitly configured, preventing unnecessary fetches for the single-threaded core in `js/audio-processor.js`.
- Pass `workerURL` to `ffmpeg.load()` only when a worker blob exists and safely guard `URL.revokeObjectURL()` calls to avoid revoking `null` values.
- Removed the non-existent `ffmpeg-core.worker.js` from the service worker CDN asset list in `sw.js` so runtime/offline caching matches actual runtime dependencies.
- Added a regression test `tests/audio-processor-config.test.js` that asserts the default FFmpeg core configuration does not attempt to fetch the missing worker script, and updated `CHANGELOG.md` and `CLAUDE.md` documentation to record the fix.

### Testing
- Ran the new Node regression test with `node tests/audio-processor-config.test.js` and it passed locally (assertion succeeded).
- Ran JavaScript syntax checks with `node --check` across the key JS files and they passed: `js/version.js`, `js/fft.js`, `js/tempo-detector.js`, `js/key-detector.js`, `js/analysis-worker.js`, `js/audio-processor.js`, `js/app.js`, `sw.js`, and `api/fetch.js`.
- Verified repository smoke checks (`test -f README.md && test -f CHANGELOG.md && test -f LICENSE && test -f SECURITY.md && test -f .editorconfig && test -f index.html && test -f css/styles.css && test -f js/app.js && test -f js/audio-processor.js && test -f docs/MANIFEST.md`) and the version/cache consistency Python check both passed in this environment.
- Note: live CDN/media browser verification was not possible here because outbound requests to `unpkg.com` returned `Tunnel connection failed: 403 Forbidden`; to fully validate runtime FFmpeg downloads in a browser, run the app in a normal networked browser and exercise a file and URL processing flow (start the dev server with `python3 server.py` and open `http://127.0.0.1:50910/`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a325712f634832f9161f101152055c9)