### PR TITLE
ci: add workflow_dispatch trigger to CI and Pages deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  # Manual fallback: run CI from the Actions tab when event-triggered runs
+  # are unavailable (e.g. Actions paused or billing-limited)
+  workflow_dispatch:
 
 jobs:
   validate:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Manual fallback: run the Pages deploy from the Actions tab when
+  # event-triggered runs are unavailable (e.g. Actions paused or billing-limited)
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

GitHub Actions has not fired on this repo since **2026-03-13**: both the `CI` and `Deploy to GitHub Pages` workflows show state "active" but produced zero runs for merged PRs #32–#37, despite unchanged workflow files. That means nothing merged since March has been CI-validated, and the GitHub Pages site is serving a stale pre-2.4.1 build — without the upload/processing fix from #37. A gap this abrupt and repo-wide points to an account-level cause (Actions paused, spending limit, or billing), which only the repo owner can resolve in GitHub settings.

## Change

Adds a `workflow_dispatch:` trigger (with an explanatory comment) to both workflows:

- `.github/workflows/ci.yml`
- `.github/workflows/deploy-pages.yml`

Once Actions is unblocked, this allows running CI and — more importantly — redeploying GitHub Pages with the v2.4.1 fix manually from the Actions tab, without needing a new push to `main`. Trigger-only change; job steps are untouched.

## How verified

- Both files parse cleanly as YAML (`yaml.safe_load`).
- No change to jobs, permissions, or concurrency — only the `on:` block gains `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCAnPSN7rpM9QQ6D9jhBJg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCAnPSN7rpM9QQ6D9jhBJg)_