### PR TITLE
feat: v2.4.2 — waveform playback progress, keyboard accessibility, playback robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to reSOURCERY will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2026-07-12
+
+### Added
+- **Waveform playback progress**: the results waveform now renders the played portion in bright cyan with the remainder dimmed, updating live during playback and when seeking, and resetting when playback ends.
+- **Keyboard accessibility**: the drop zone is focusable (`role="button"`, `tabindex="0"`) and opens the file browser on Enter/Space; Escape closes the settings panel; all interactive controls (drop zone, format buttons, play button, seek bar, URL submit, cancel/close buttons) show a visible `:focus-visible` outline.
+- **Screen reader support**: toast notifications are announced via `role="status"`/`aria-live="polite"`; the cancel-processing and close-settings icon buttons have `aria-label`s.
+
+### Fixed
+- **Concurrent conversion guard**: clicking a second download format (or double-clicking) while a conversion is running is now ignored; the other format buttons are visibly disabled until the conversion finishes.
+- **Waveform resize**: the waveform canvas redraws on window resize/orientation change instead of stretching and blurring.
+- **Seek before metadata**: seeking or time updates before audio metadata loads no longer produce `NaN` seek-bar values or invalid `currentTime` assignments.
+- **Playback errors**: `audio.play()` rejections (e.g. decode/autoplay failures) are caught, the play button state is reverted, and an error toast is shown instead of a stuck "playing" UI.
+- **Deprecated event**: URL input now uses `keydown` instead of the deprecated `keypress` event.
+
+### Changed
+- Error toasts stay visible for 5 seconds (info/success remain 3 seconds) so failure messages can actually be read.
+- Service worker cache bumped to `resourcery-v2.4.2`.
+
 ## [2.4.1] - 2026-07-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-2.4.1-blue.svg" alt="Version"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-2.4.2-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg" alt="License"></a>
   <a href="https://github.com/SeanVasey/reSOURCERY/actions/workflows/ci.yml"><img src="https://github.com/SeanVasey/reSOURCERY/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/badge/platform-Web%20%7C%20iOS%20%7C%20Android-lightgrey.svg" alt="Platform">
@@ -137,7 +137,7 @@ reSOURCERY/
 ├── vercel.json             # Vercel deployment headers, rewrites, and API support
 ├── api/
 │   └── fetch.js            # Hardened URL proxy endpoint for CORS fallback
-├── sw.js                   # Service worker (v2.4.1)
+├── sw.js                   # Service worker (v2.4.2)
 ├── coi-serviceworker.js    # Cross-Origin Isolation for SharedArrayBuffer
 ├── css/
 │   └── styles.css          # Dark slate + indigo/cyan wizard theme
@@ -186,6 +186,7 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
 | Version | Date       | Summary                                |
 | ------- | ---------- | -------------------------------------- |
+| 2.4.2   | 2026-07-12 | Waveform playback progress, keyboard accessibility (focusable drop zone, Escape, focus outlines), conversion re-entry guard, playback/seek robustness fixes |
 | 2.4.1   | 2026-07-10 | Fix broken upload/processing: vendor @ffmpeg/ffmpeg wrapper same-origin (cross-origin worker was rejected) |
 | 2.4.0   | 2026-02-27 | DNS rebinding mitigation, IPv6 fe80::/10 fix, CSP on proxy, streaming timeouts |
 | 2.3.1   | 2026-02-27 | SSRF hardening (IPv6, DNS resolution, redirect validation), streaming proxy responses |

--- a/css/styles.css
+++ b/css/styles.css
@@ -1881,6 +1881,27 @@ body::before {
   }
 }
 
+/* Keyboard focus visibility */
+.drop-zone:focus-visible,
+.format-btn:focus-visible,
+.play-btn:focus-visible,
+.url-submit-btn:focus-visible,
+.new-extract-btn:focus-visible,
+.cancel-btn:focus-visible,
+.settings-close:focus-visible,
+.floating-menu-btn:focus-visible,
+.seek-bar:focus-visible {
+  outline: 2px solid var(--cyan-400);
+  outline-offset: 3px;
+}
+
+/* Format buttons locked while a conversion runs */
+.format-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 /* Dark mode forced for consistency */
 @media (prefers-color-scheme: light) {
   :root {

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <div class="brand-row">
         <img class="app-logo" src="icons/reSOURCERY_optimized.svg" alt="reSOURCERY" />
         <h1 class="app-title">reSOURCERY</h1>
-        <span class="version-badge" id="versionBadge">v2.4.1</span>
+        <span class="version-badge" id="versionBadge">v2.4.2</span>
       </div>
 
       <!-- Subtitle -->
@@ -84,7 +84,7 @@
         </div>
 
         <!-- Drop Zone -->
-        <div class="drop-zone glass-panel" id="dropZone">
+        <div class="drop-zone glass-panel" id="dropZone" role="button" tabindex="0" aria-label="Upload media file — drag and drop, or press Enter to browse">
           <div class="drop-zone-content">
             <div class="drop-icon-container">
               <svg class="drop-icon" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -116,7 +116,7 @@
         <div class="glass-panel processing-panel">
           <div class="processing-header">
             <h3 class="processing-title">ANALYZING MEDIA</h3>
-            <button class="cancel-btn" id="cancelBtn">
+            <button class="cancel-btn" id="cancelBtn" aria-label="Cancel processing">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <line x1="18" y1="6" x2="6" y2="18"></line>
                 <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -397,7 +397,7 @@
         </a>
       </div>
       <div class="footer-suite-tag">A VASEY/AI Production</div>
-      <div class="footer-app-tag">reSOURCERY v2.4.1 &middot; Audio Extraction Studio</div>
+      <div class="footer-app-tag">reSOURCERY v2.4.2 &middot; Audio Extraction Studio</div>
       <div class="footer-copyright">
         &copy; 2026 <a href="https://vaseymultimedia.com" target="_blank" rel="noopener">VASEY Multimedia</a>. All rights reserved.<br>
         Designed &amp; engineered by <a href="https://vasey.ai" target="_blank" rel="noopener">VASEY/AI</a>
@@ -410,7 +410,7 @@
       <div class="settings-content glass-panel">
         <div class="settings-header">
           <h3 class="settings-title">SETTINGS</h3>
-          <button class="settings-close" id="settingsClose">
+          <button class="settings-close" id="settingsClose" aria-label="Close settings">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="18" y1="6" x2="6" y2="18"></line>
               <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -441,13 +441,13 @@
           </div>
         </div>
         <div class="settings-footer">
-          <span class="version-text" id="settingsVersion">v2.4.1</span>
+          <span class="version-text" id="settingsVersion">v2.4.2</span>
         </div>
       </div>
     </div>
 
     <!-- Toast Notifications -->
-    <div class="toast-container" id="toastContainer"></div>
+    <div class="toast-container" id="toastContainer" role="status" aria-live="polite"></div>
   </div>
 
   <!-- Top safe-area scrim: masks content scrolling under the iOS status bar / Dynamic Island -->

--- a/js/app.js
+++ b/js/app.js
@@ -22,6 +22,8 @@ class ReSOURCERYApp {
     this.currentResult = null;
     this.waveformData = [];
     this.audioObjectURL = null;
+    this.isConverting = false;
+    this.resizeTimer = null;
 
     // DOM Elements
     this.elements = {};
@@ -138,12 +140,18 @@ class ReSOURCERYApp {
   bindEvents() {
     // URL input
     this.elements.urlSubmitBtn.addEventListener('click', () => this.handleURLSubmit());
-    this.elements.urlInput.addEventListener('keypress', (e) => {
+    this.elements.urlInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') this.handleURLSubmit();
     });
 
     // File drop zone
     this.elements.dropZone.addEventListener('click', () => this.elements.fileInput.click());
+    this.elements.dropZone.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        this.elements.fileInput.click();
+      }
+    });
     this.elements.dropZone.addEventListener('dragover', (e) => this.handleDragOver(e));
     this.elements.dropZone.addEventListener('dragleave', (e) => this.handleDragLeave(e));
     this.elements.dropZone.addEventListener('drop', (e) => this.handleDrop(e));
@@ -190,6 +198,23 @@ class ReSOURCERYApp {
     this.elements.showWaveform.addEventListener('change', (e) => {
       this.settings.showWaveform = e.target.checked;
       this.saveSettings();
+    });
+
+    // Escape closes the settings panel
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !this.elements.settingsPanel.classList.contains('hidden')) {
+        this.toggleSettings(false);
+      }
+    });
+
+    // Redraw waveform when the viewport changes (resize / orientation)
+    window.addEventListener('resize', () => {
+      clearTimeout(this.resizeTimer);
+      this.resizeTimer = setTimeout(() => {
+        if (!this.elements.resultsSection.classList.contains('hidden')) {
+          this.drawWaveform(this.getPlaybackProgress());
+        }
+      }, 150);
     });
 
     // Prevent default behaviors
@@ -489,9 +514,11 @@ class ReSOURCERYApp {
 
   /**
    * Draw waveform visualization
+   * @param {number} progress - Playback position 0..1; bars before it render brighter
    */
-  drawWaveform() {
+  drawWaveform(progress = 0) {
     const canvas = this.elements.waveformCanvas;
+    if (!canvas || !this.waveformData.length) return;
     const ctx = canvas.getContext('2d');
 
     // Set canvas size
@@ -509,19 +536,24 @@ class ReSOURCERYApp {
     // Draw waveform
     const barWidth = width / this.waveformData.length;
     const centerY = height / 2;
+    const playedBars = Math.floor(progress * this.waveformData.length);
 
-    // Create gradient
+    // Unplayed bars: dim gradient; played bars: bright cyan
     const gradient = ctx.createLinearGradient(0, 0, 0, height);
-    gradient.addColorStop(0, 'rgba(34, 211, 238, 0.8)');
-    gradient.addColorStop(0.5, 'rgba(13, 148, 136, 0.6)');
-    gradient.addColorStop(1, 'rgba(34, 211, 238, 0.8)');
+    gradient.addColorStop(0, 'rgba(34, 211, 238, 0.35)');
+    gradient.addColorStop(0.5, 'rgba(13, 148, 136, 0.25)');
+    gradient.addColorStop(1, 'rgba(34, 211, 238, 0.35)');
 
-    ctx.fillStyle = gradient;
+    const playedGradient = ctx.createLinearGradient(0, 0, 0, height);
+    playedGradient.addColorStop(0, 'rgba(34, 211, 238, 0.95)');
+    playedGradient.addColorStop(0.5, 'rgba(45, 212, 191, 0.75)');
+    playedGradient.addColorStop(1, 'rgba(34, 211, 238, 0.95)');
 
     for (let i = 0; i < this.waveformData.length; i++) {
       const value = this.waveformData[i];
       const barHeight = value * height * 0.8;
 
+      ctx.fillStyle = i < playedBars ? playedGradient : gradient;
       ctx.fillRect(
         i * barWidth,
         centerY - barHeight / 2,
@@ -532,14 +564,31 @@ class ReSOURCERYApp {
   }
 
   /**
+   * Current playback position as a 0..1 fraction
+   */
+  getPlaybackProgress() {
+    const duration = this.audioElement.duration;
+    if (!duration || !isFinite(duration)) return 0;
+    return this.audioElement.currentTime / duration;
+  }
+
+  /**
    * Handle format selection
    */
   async handleFormatSelect(button) {
+    // Ignore clicks while a conversion is already running
+    if (this.isConverting) return;
+    this.isConverting = true;
+
     const format = button.dataset.format;
 
     // Update UI
-    this.elements.formatBtns.forEach(btn => btn.classList.remove('selected'));
+    this.elements.formatBtns.forEach(btn => {
+      btn.classList.remove('selected');
+      btn.disabled = true;
+    });
     button.classList.add('selected');
+    button.disabled = false;
 
     // Show download progress
     this.elements.downloadProgress.classList.remove('hidden');
@@ -580,6 +629,8 @@ class ReSOURCERYApp {
     } finally {
       // Restore the original progress callback
       this.processor.onProgress = originalOnProgress;
+      this.isConverting = false;
+      this.elements.formatBtns.forEach(btn => { btn.disabled = false; });
     }
   }
 
@@ -606,9 +657,14 @@ class ReSOURCERYApp {
       this.isPlaying = false;
       this.elements.playBtn.classList.remove('playing');
     } else {
-      this.audioElement.play();
       this.isPlaying = true;
       this.elements.playBtn.classList.add('playing');
+      this.audioElement.play().catch((error) => {
+        console.error('[reSOURCERY] Playback failed:', error);
+        this.isPlaying = false;
+        this.elements.playBtn.classList.remove('playing');
+        this.showToast('Playback failed. Please try again.', 'error');
+      });
     }
   }
 
@@ -616,8 +672,13 @@ class ReSOURCERYApp {
    * Handle seek
    */
   handleSeek(e) {
+    const duration = this.audioElement.duration;
+    if (!duration || !isFinite(duration)) return;
     const percent = e.target.value / 100;
-    this.audioElement.currentTime = percent * this.audioElement.duration;
+    this.audioElement.currentTime = percent * duration;
+    if (this.settings.showWaveform) {
+      this.drawWaveform(percent);
+    }
   }
 
   /**
@@ -628,7 +689,12 @@ class ReSOURCERYApp {
     const duration = this.audioElement.duration;
 
     this.elements.currentTime.textContent = this.formatTime(current);
-    this.elements.seekBar.value = (current / duration) * 100;
+    if (duration && isFinite(duration)) {
+      this.elements.seekBar.value = (current / duration) * 100;
+      if (this.settings.showWaveform) {
+        this.drawWaveform(current / duration);
+      }
+    }
   }
 
   /**
@@ -645,6 +711,9 @@ class ReSOURCERYApp {
     this.isPlaying = false;
     this.elements.playBtn.classList.remove('playing');
     this.elements.seekBar.value = 0;
+    if (this.settings.showWaveform) {
+      this.drawWaveform(0);
+    }
   }
 
   /**
@@ -906,11 +975,12 @@ class ReSOURCERYApp {
 
     this.elements.toastContainer.appendChild(toast);
 
-    // Remove after delay
+    // Remove after delay — errors linger longer so they can be read
+    const duration = type === 'error' ? 5000 : 3000;
     setTimeout(() => {
       toast.classList.add('toast-out');
       setTimeout(() => toast.remove(), 300);
-    }, 3000);
+    }, duration);
   }
 
   /**

--- a/js/version.js
+++ b/js/version.js
@@ -10,7 +10,7 @@
 const APP_VERSION = Object.freeze({
   major: 2,
   minor: 4,
-  patch: 1,
+  patch: 2,
 
   /** Full semver string, e.g. "2.1.0" */
   get full() {

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 try { importScripts('./js/version.js'); } catch (e) { /* version.js unavailable */ }
 const CACHE_NAME = (typeof APP_VERSION !== 'undefined' && APP_VERSION.cacheKey)
   ? APP_VERSION.cacheKey
-  : 'resourcery-v2.4.1';
+  : 'resourcery-v2.4.2';
 const STATIC_ASSETS = [
   './',
   './index.html',

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,7 +2,19 @@
 
 Active task tracking for Claude Code sessions.
 
-## Current Session (2026-07-10)
+## Current Session (2026-07-12)
+
+- [x] Survey app.js / index.html / styles.css for small functionality & design gaps
+- [x] Waveform: live playback progress rendering + redraw on resize/orientation change
+- [x] Keyboard a11y: focusable drop zone (Enter/Space), Escape closes settings, `:focus-visible` outlines
+- [x] Screen readers: aria-live toast container, aria-labels on icon-only buttons
+- [x] Guard concurrent format conversions (disable other format buttons while converting)
+- [x] Playback robustness: NaN seek-bar guard pre-metadata, `play()` rejection handling
+- [x] Error toasts linger 5s; URL input keypress → keydown
+- [x] Bump to v2.4.2 (version.js, sw.js fallback, index.html, README, CHANGELOG)
+- [x] Verify: syntax + baseline + version checks; headless-Chromium E2E (upload → results → playback → seek → MP3 download, waveform-progress pixel assert, conversion-guard assert)
+
+## Session (2026-07-10)
 
 - [x] Reproduce report: file upload / processing fails on every attempt
 - [x] Root-cause: CDN-hosted @ffmpeg/ffmpeg wrapper spawns cross-origin class worker (814.ffmpeg.js) → SecurityError in ffmpeg.load()


### PR DESCRIPTION
## Summary

A focused set of small functionality and design improvements, released as **v2.4.2**.

### Functionality
- **Waveform playback progress** — the results waveform now renders the played portion in bright cyan with the remainder dimmed, updating live during playback and on seek, resetting when playback ends. It also redraws on window resize / orientation change instead of stretching and blurring.
- **Concurrent conversion guard** — clicking a second download format (or double-clicking) while a conversion is running is ignored; the other format buttons are visibly disabled until it finishes.
- **Playback robustness** — seek/timeupdate no longer produce `NaN` seek-bar values before audio metadata loads; `audio.play()` rejections are caught, the play-button state reverts, and an error toast is shown instead of a stuck "playing" UI.
- **Deprecated event** — the URL input uses `keydown` instead of the deprecated `keypress`.

### Accessibility & design
- Drop zone is keyboard-operable (`role="button"`, `tabindex="0"`, Enter/Space opens the file browser).
- Escape closes the settings panel.
- `:focus-visible` outlines on all interactive controls (drop zone, format buttons, play button, seek bar, URL submit, cancel/close/menu buttons).
- Toast container is an `aria-live` status region; the cancel-processing and close-settings icon-only buttons have `aria-label`s.
- Error toasts stay visible 5 s (info/success remain 3 s) so failure messages can actually be read.

### Version bump (per checklist)
- `js/version.js` → 2.4.2, `sw.js` fallback cache name → `resourcery-v2.4.2`, static version strings in `index.html` (badge, settings, footer), README badge + version table, CHANGELOG entry, `tasks/todo.md` session log.

## How verified

- `node --check` on all JS files, repository baseline smoke checks, and version consistency (`sw.js` fallback == `APP_VERSION.cacheKey`) all pass; existing `tests/audio-processor-config.test.js` passes.
- Headless-Chromium E2E against `server.py`: WAV upload → extraction → tempo/key results (44.1 kHz, 120 BPM) → playback → seek → MP3 conversion download. The run asserts the new behaviors directly: file chooser opens from keyboard Enter on the focused drop zone, Escape closes settings, the played half of the waveform canvas is measurably brighter than the unplayed half after seeking to 50%, other format buttons are `disabled` during conversion and re-enabled after, and the MP3 download event fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019t8qK13idC1wvkzs8JjNnq

---
_Generated by [Claude Code](https://claude.ai/code/session_019t8qK13idC1wvkzs8JjNnq)_