### PR TITLE
chore: faster icon cache propagation + full-bleed source audit (v2.4.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to reSOURCERY will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.6] - 2026-07-16
+
+### Changed
+- **Icon assets now propagate faster when they change.** `/icons/*` previously used `Cache-Control: public, max-age=604800` (a hard 7-day cache with no revalidation), so an updated favicon/PWA icon could take up to a week to reach returning browsers. It now uses `public, max-age=86400, stale-while-revalidate=604800` — fresh for a day, then served stale-while-revalidating for up to a week — matching the JS/CSS caching convention. Added the same header for the root `favicon.ico` and `resourcery-icon-ios.svg`, which previously fell back to Vercel's default caching. (Note: this only affects browser/HTTP caching; iOS Home Screen webclip icons are cached by the OS and are not governed by HTTP headers — evicting those still requires removing and re-adding the icon.)
+
+### Verified
+- Audited every icon surface: all favicon, PWA, and iOS Home Screen rasters (`apple-touch-icon.png`, `icon-192/512.png`, `icon-maskable-512.png`, `favicon-16/32.png`, `favicon.ico`) are byte-for-byte reproducible from the full-bleed `resourcery-icon-ios.svg`, are fully opaque, and carry the uniform `#5f86ff` border. The in-app header logo remains the transparent `icons/reSOURCERY_optimized.svg`.
+
 ## [2.4.5] - 2026-07-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-2.4.5-blue.svg" alt="Version"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-2.4.6-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg" alt="License"></a>
   <a href="https://github.com/SeanVasey/reSOURCERY/actions/workflows/ci.yml"><img src="https://github.com/SeanVasey/reSOURCERY/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/badge/platform-Web%20%7C%20iOS%20%7C%20Android-lightgrey.svg" alt="Platform">
@@ -137,7 +137,7 @@ reSOURCERY/
 ├── vercel.json             # Vercel deployment headers, rewrites, and API support
 ├── api/
 │   └── fetch.js            # Hardened URL proxy endpoint for CORS fallback
-├── sw.js                   # Service worker (v2.4.5)
+├── sw.js                   # Service worker (v2.4.6)
 ├── coi-serviceworker.js    # Cross-Origin Isolation for SharedArrayBuffer
 ├── css/
 │   └── styles.css          # Dark slate + indigo/cyan wizard theme
@@ -192,6 +192,7 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
 | Version | Date       | Summary                                |
 | ------- | ---------- | -------------------------------------- |
+| 2.4.6   | 2026-07-16 | Faster icon-update propagation: `/icons/*`, `favicon.ico`, and the SVG icon now use `max-age=86400, stale-while-revalidate`; audited that every favicon/PWA/iOS raster derives from the full-bleed `resourcery-icon-ios.svg` |
 | 2.4.5   | 2026-07-16 | Fix white/uneven fringe on the iOS Home Screen icon: the full-bleed plate's pale-topped gradient read as a whitish rim once iOS masked its squircle — replaced with a uniform brand blue so the border is one clean color; regenerated the raster set |
 | 2.4.4   | 2026-07-16 | Refresh iOS/PWA app icon: full-bleed opaque plate (edge-to-edge, iOS applies its own squircle mask); regenerate the raster icon set + `favicon.ico` from the updated `resourcery-icon-ios.svg` |
 | 2.4.3   | 2026-07-16 | Branded iOS Home Screen / PWA icon (`resourcery-icon-ios.svg`); PNG favicon + Apple touch + maskable set; fix iOS ignoring the SVG apple-touch-icon |

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
       <div class="brand-row">
         <img class="app-logo" src="icons/reSOURCERY_optimized.svg" alt="reSOURCERY" />
         <h1 class="app-title">reSOURCERY</h1>
-        <span class="version-badge" id="versionBadge">v2.4.5</span>
+        <span class="version-badge" id="versionBadge">v2.4.6</span>
       </div>
 
       <!-- Subtitle -->
@@ -400,7 +400,7 @@
         </a>
       </div>
       <div class="footer-suite-tag">A VASEY/AI Production</div>
-      <div class="footer-app-tag">reSOURCERY v2.4.5 &middot; Audio Extraction Studio</div>
+      <div class="footer-app-tag">reSOURCERY v2.4.6 &middot; Audio Extraction Studio</div>
       <div class="footer-copyright">
         &copy; 2026 <a href="https://vaseymultimedia.com" target="_blank" rel="noopener">VASEY Multimedia</a>. All rights reserved.<br>
         Designed &amp; engineered by <a href="https://vasey.ai" target="_blank" rel="noopener">VASEY/AI</a>
@@ -444,7 +444,7 @@
           </div>
         </div>
         <div class="settings-footer">
-          <span class="version-text" id="settingsVersion">v2.4.5</span>
+          <span class="version-text" id="settingsVersion">v2.4.6</span>
         </div>
       </div>
     </div>

--- a/js/version.js
+++ b/js/version.js
@@ -10,7 +10,7 @@
 const APP_VERSION = Object.freeze({
   major: 2,
   minor: 4,
-  patch: 5,
+  patch: 6,
 
   /** Full semver string, e.g. "2.1.0" */
   get full() {

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 try { importScripts('./js/version.js'); } catch (e) { /* version.js unavailable */ }
 const CACHE_NAME = (typeof APP_VERSION !== 'undefined' && APP_VERSION.cacheKey)
   ? APP_VERSION.cacheKey
-  : 'resourcery-v2.4.5';
+  : 'resourcery-v2.4.6';
 const STATIC_ASSETS = [
   './',
   './index.html',

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,14 @@
 
 Active task tracking for Claude Code sessions.
 
+## Session (2026-07-16) — Icon cache propagation + full-bleed source audit
+
+- [x] Confirm the v2.4.5 fix is actually live on production (resourcery.vercel.app icon byte-identical to local, corners #5f86ff) — "still same" was device/HTTP caching
+- [x] Audit: regenerate all icons from resourcery-icon-ios.svg → zero diff vs committed (all derive from the full-bleed source); every raster opaque with uniform #5f86ff border; favicon.ico = 3 PNG entries
+- [x] Confirm references: apple-touch-icon / favicon SVG+PNG+ICO / manifest icons all → full-bleed source; in-app header logo → transparent reSOURCERY_optimized.svg
+- [x] vercel.json: `/icons/*` 7-day hard cache → `max-age=86400, stale-while-revalidate=604800`; add same header for root favicon.ico + resourcery-icon-ios.svg
+- [x] Bump to v2.4.6; update CHANGELOG/README/index; verify syntax + version consistency + JSON valid
+
 ## Session (2026-07-16) — Fix white/uneven fringe on iOS Home Screen icon
 
 - [x] Diagnose from user's Home Screen screenshot: white/uneven rim on the squircle corners

--- a/vercel.json
+++ b/vercel.json
@@ -62,7 +62,16 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=604800"
+          "value": "public, max-age=86400, stale-while-revalidate=604800"
+        }
+      ]
+    },
+    {
+      "source": "/(favicon.ico|resourcery-icon-ios.svg)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate=604800"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Two things, following up on the icon work:

### 1. Faster icon-update propagation (caching)

`/icons/*` used `Cache-Control: public, max-age=604800` — a hard **7-day** cache with no revalidation, so an updated favicon/PWA icon could take up to a week to reach returning browsers. Changed to:

```
public, max-age=86400, stale-while-revalidate=604800
```

Fresh for a day, then served stale-while-revalidating for up to a week — matching the existing JS/CSS caching convention in `vercel.json`. Also added the same header for the root `favicon.ico` and `resourcery-icon-ios.svg`, which previously fell back to Vercel's default caching.

> This affects **browser/HTTP caching only**. iOS Home Screen webclip icons are cached by the OS and are *not* governed by HTTP headers — evicting those still requires removing and re-adding the icon (or a device restart).

### 2. Full-bleed source audit (per request)

Confirmed every favicon / PWA / iOS Home Screen raster derives from the full-bleed `resourcery-icon-ios.svg`:

- **Regenerating all icons from source produced zero diff** against the committed files — they're byte-for-byte reproducible from the correct source.
- All rasters are **fully opaque** with the uniform `#5f86ff` border; `favicon.ico` holds 3 PNG entries (16/32/48).
- **References verified:** `apple-touch-icon`, favicon SVG/PNG/ICO, and all `manifest.json` icons point at the full-bleed source; the in-app header logo remains the transparent `icons/reSOURCERY_optimized.svg`.

Bumped to **v2.4.6** (`version.js`, `sw.js` fallback, `index.html`, `README`, `CHANGELOG`).

## Verification

- `node --check` on `version.js`/`sw.js`; `vercel.json` + `manifest.json` parse; version consistency (`sw.js` fallback == `APP_VERSION.cacheKey` == `resourcery-v2.4.6`).
- Confirmed the earlier v2.4.5 fix is **already live on production** — `resourcery.vercel.app/icons/apple-touch-icon.png` is byte-identical (same MD5) to the corrected local file, with uniform `#5f86ff` corners. So the "still looks the same" report was client-side caching, not a stale deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kNXBqFMrWjrJ52YwN6w8G

---
_Generated by [Claude Code](https://claude.ai/code/session_014kNXBqFMrWjrJ52YwN6w8G)_